### PR TITLE
Wrong resistors on pcb

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pi-pico-alarmclock"
-version = "0.7.2"
+version = "0.7.3"
 edition = "2024"
 authors = ["rafael.koch@gmx.net"]
 description = "Raspberry Pi Pico W alarm clock with WiFi, time sync, OLED display, and WS2812 LED support"

--- a/README.md
+++ b/README.md
@@ -452,7 +452,7 @@ Designed in FreeCAD 1.0. Export files available: [enclosure/](enclosure/)
 |R6|1|2.2kΩ|
 |R8|1|220Ω|
 |R9, R11|2|100kΩ|
-|R10, R12|2|200kΩ|
+|R10, R12|2|220kΩ|
 
 ### Capacitors
 |Reference|Qty|Type|Value|Voltage|Description|
@@ -478,7 +478,7 @@ Designed in FreeCAD 1.0. Export files available: [enclosure/](enclosure/)
 
 ### Power Detection Noise Filtering
 
-The USB power and battery voltage detection uses voltage dividers (200kΩ/100kΩ) with 100nF filter capacitors that help reduce electrical noise from NeoPixel switching and EMI in the enclosure. Software filtering further improves stability:
+The USB power and battery voltage detection uses voltage dividers (220kΩ/100kΩ) with 100nF filter capacitors that help reduce electrical noise from NeoPixel switching and EMI in the enclosure. Software filtering further improves stability:
 
 
 **USB Detection (VBUS):**

--- a/circuit/pi-pico-alarmclock/pi-pico-alarmclock.kicad_pcb
+++ b/circuit/pi-pico-alarmclock/pi-pico-alarmclock.kicad_pcb
@@ -1588,7 +1588,7 @@
 				)
 			)
 		)
-		(property "Value" "200K"
+		(property "Value" "220K"
 			(at 5.08 0 90)
 			(layer "F.SilkS")
 			(uuid "2119fe39-f2bf-4eca-ad1e-c9159ededa14")
@@ -3661,7 +3661,7 @@
 				)
 			)
 		)
-		(property "Value" "200K"
+		(property "Value" "220K"
 			(at 5.08 0 90)
 			(layer "F.SilkS")
 			(uuid "991fb6c1-a6f4-4565-a29d-f9ce0a244053")
@@ -3709,7 +3709,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "8687747d-4163-402e-a637-79c723960a74")
+			(uuid "dca33505-1990-44c6-8bbe-832559fa264d")
 		)
 		(fp_line
 			(start 9.12 0)
@@ -3719,7 +3719,7 @@
 				(type solid)
 			)
 			(layer "F.SilkS")
-			(uuid "ab00f2ad-a826-4fad-8324-d7af20d14bc7")
+			(uuid "88b5eeff-e1b7-41b0-ad1a-af97b71347d3")
 		)
 		(fp_rect
 			(start 1.81 -1.37)
@@ -3730,7 +3730,7 @@
 			)
 			(fill no)
 			(layer "F.SilkS")
-			(uuid "eb7b9f8b-0f95-4175-894f-412881f3dc0d")
+			(uuid "2a1bc0dd-b469-4bbf-9ccf-dcc5043fa743")
 		)
 		(fp_rect
 			(start -1.05 -1.5)
@@ -3741,7 +3741,7 @@
 			)
 			(fill no)
 			(layer "F.CrtYd")
-			(uuid "ef5bfbbb-6fb7-411a-8488-83da72f0df27")
+			(uuid "1ca00089-74ea-4fc3-a6d6-a4bb4bf59a8c")
 		)
 		(fp_line
 			(start 0 0)
@@ -3751,7 +3751,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "90e6e84e-7da8-4633-8f3c-17879fa57f68")
+			(uuid "de806a29-a92c-418f-8bee-71353db1430d")
 		)
 		(fp_line
 			(start 10.16 0)
@@ -3761,7 +3761,7 @@
 				(type solid)
 			)
 			(layer "F.Fab")
-			(uuid "0d8684a7-c546-4a7e-ad42-904d974d1835")
+			(uuid "49a0b34f-2f2a-4851-b132-b9f06623f7e9")
 		)
 		(fp_rect
 			(start 1.93 -1.25)
@@ -3772,7 +3772,7 @@
 			)
 			(fill no)
 			(layer "F.Fab")
-			(uuid "d22324c1-595e-4bbe-b46e-b1f9b5a65d0f")
+			(uuid "ea47d111-ddff-45d2-a819-0666dd0ec7d5")
 		)
 		(fp_text user "${REFERENCE}"
 			(at 5.08 0 90)
@@ -16096,7 +16096,7 @@
 			(justify left bottom)
 		)
 	)
-	(gr_text "1-rafael-1\nPi Pico Alarmclock\nV0.3 / 12.2025"
+	(gr_text "1-rafael-1\nPi Pico Alarmclock\nV0.4 / 01.2026"
 		(at 122.75 55 0)
 		(layer "F.SilkS")
 		(uuid "7b5e74eb-7205-42b4-a6b1-4dda3b1dfbb0")

--- a/circuit/pi-pico-alarmclock/pi-pico-alarmclock.kicad_sch
+++ b/circuit/pi-pico-alarmclock/pi-pico-alarmclock.kicad_sch
@@ -6,8 +6,8 @@
 	(paper "A4")
 	(title_block
 		(title "pi-pico-alarmclock-rust")
-		(date "2025-11-20")
-		(rev "v0.3")
+		(date "2026-01-06")
+		(rev "v0.4")
 		(company "rafael")
 	)
 	(lib_symbols
@@ -8168,7 +8168,7 @@
 				)
 			)
 		)
-		(property "Value" "200K"
+		(property "Value" "220K"
 			(at 195.58 97.79 0)
 			(effects
 				(font
@@ -9721,7 +9721,7 @@
 				)
 			)
 		)
-		(property "Value" "200K"
+		(property "Value" "220K"
 			(at 195.58 73.66 0)
 			(effects
 				(font

--- a/src/task/power.rs
+++ b/src/task/power.rs
@@ -5,7 +5,7 @@
 //! ## Noise Filtering Strategy
 //!
 //! This module implements software filtering to compensate for
-//! voltage dividers (200kΩ/100kΩ) that may be susceptible to electrical noise, especially
+//! voltage dividers (220kΩ/100kΩ) that may be susceptible to electrical noise, especially
 //! from `NeoPixel` switching and EMI in the enclosure environment.
 //!
 //! ### USB Power Detection (VBUS)
@@ -152,8 +152,8 @@ pub async fn vsys_voltage_reader(mut adc: Adc<'static, embassy_rp::adc::Async>, 
             // Get median value (outlier spikes automatically rejected!)
             let median_adc_value = median_filter.median();
 
-            // reference voltage is 3.3V, and the voltage divider ratio is 3.0 (R10: 200kΩ + R9: 100kΩ) / 100kΩ. The ADC is 12-bit, so 2^12 = 4096
-            let voltage = f32::from(median_adc_value) * 3.3 * 3.0 / 4096.0;
+            // reference voltage is 3.3V, and the voltage divider ratio is 3.2 (R10: 220kΩ + R9: 100kΩ) / 100kΩ. The ADC is 12-bit, so 2^12 = 4096
+            let voltage = f32::from(median_adc_value) * 3.3 * 3.2 / 4096.0;
 
             info!(
                 "Vsys voltage reading: {}V (median filtered from {} samples)",


### PR DESCRIPTION
This pull request updates the voltage divider resistors used for USB power and battery voltage detection from 200kΩ to 220kΩ in both the hardware design and documentation. The change is reflected throughout the KiCad schematic, PCB, Rust source code, and documentation to ensure consistency in design, implementation, and explanation.

**Hardware and Documentation Updates:**

* Updated the resistor values for R10 and R12 from 200kΩ to 220kΩ in the bill of materials and power detection description in `README.md`. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L455-R455) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L481-R481)
* Changed the voltage divider resistor values from 200kΩ to 220kΩ in the KiCad schematic (`.kicad_sch`) and PCB layout (`.kicad_pcb`) files to match the new design. [[1]](diffhunk://#diff-b8e5cf58c10c7aba133c70f2403d3a015252383034a97898ae57be4eb9b688a1L1591-R1591) [[2]](diffhunk://#diff-b8e5cf58c10c7aba133c70f2403d3a015252383034a97898ae57be4eb9b688a1L3664-R3664) [[3]](diffhunk://#diff-6a48af5e4a1001f4ec501b466aaa7fd7b4d9a86f6548ae3c283a7e87dd2304bfL8171-R8171) [[4]](diffhunk://#diff-6a48af5e4a1001f4ec501b466aaa7fd7b4d9a86f6548ae3c283a7e87dd2304bfL9724-R9724)

**Firmware and Calculation Adjustments:**

* Updated the voltage divider ratio in the Rust code (`src/task/power.rs`) from 3.0 (200kΩ + 100kΩ) / 100kΩ to 3.2 (220kΩ + 100kΩ) / 100kΩ, and adjusted all related comments and calculations. [[1]](diffhunk://#diff-b17cc6bb671287226dc547b379ce001f89806cf6a9cdbc580c6be215f5f7347bL8-R8) [[2]](diffhunk://#diff-b17cc6bb671287226dc547b379ce001f89806cf6a9cdbc580c6be215f5f7347bL155-R156)

**Versioning and Metadata:**

* Bumped the project version from 0.7.2 to 0.7.3 in `Cargo.toml`, and updated hardware revision and date in schematic and PCB files to reflect the new hardware version. [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L3-R3) [[2]](diffhunk://#diff-6a48af5e4a1001f4ec501b466aaa7fd7b4d9a86f6548ae3c283a7e87dd2304bfL9-R10) [[3]](diffhunk://#diff-b8e5cf58c10c7aba133c70f2403d3a015252383034a97898ae57be4eb9b688a1L16099-R16099)

**Other (Minor):**

* Updated various UUIDs in the PCB file for consistency after editing component values. [[1]](diffhunk://#diff-b8e5cf58c10c7aba133c70f2403d3a015252383034a97898ae57be4eb9b688a1L3712-R3712) [[2]](diffhunk://#diff-b8e5cf58c10c7aba133c70f2403d3a015252383034a97898ae57be4eb9b688a1L3722-R3722) [[3]](diffhunk://#diff-b8e5cf58c10c7aba133c70f2403d3a015252383034a97898ae57be4eb9b688a1L3733-R3733) [[4]](diffhunk://#diff-b8e5cf58c10c7aba133c70f2403d3a015252383034a97898ae57be4eb9b688a1L3744-R3744) [[5]](diffhunk://#diff-b8e5cf58c10c7aba133c70f2403d3a015252383034a97898ae57be4eb9b688a1L3754-R3754) [[6]](diffhunk://#diff-b8e5cf58c10c7aba133c70f2403d3a015252383034a97898ae57be4eb9b688a1L3764-R3764) [[7]](diffhunk://#diff-b8e5cf58c10c7aba133c70f2403d3a015252383034a97898ae57be4eb9b688a1L3775-R3775)