### PR TITLE
Dark if alarm active

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pi-pico-alarmclock"
-version = "0.7.3"
+version = "0.8.0"
 edition = "2024"
 authors = ["rafael.koch@gmx.net"]
 description = "Raspberry Pi Pico W alarm clock with WiFi, time sync, OLED display, and WS2812 LED support"
@@ -72,11 +72,11 @@ serde-json-core = "0.6.0"
 
 static_cell = "2"
 portable-atomic = { version = "1.5", features = ["critical-section"] }
-pio-proc = "0.2"
+pio-proc = "0.3.0"
 
 rand = { version = "0.8.5", default-features = false }
 reqwless = { version = "0.13.0", features = ["defmt"] }
-tinybmp = "0.6.0"
+tinybmp = "0.7.0"
 dfplayer-async = { version = "0.5.0", features = ["defmt"] }
 moving_median = "0.3.0"
 
@@ -150,5 +150,3 @@ cargo_common_metadata = "warn"
 # Allow specific lints
 future_not_send = "allow" # embassy tasks are not Send
 multiple_crate_versions = "allow" # not worth the effort, we get a minimal binary size increase that does not matter here
-
-[patch.crates-io]

--- a/build.rs
+++ b/build.rs
@@ -62,7 +62,9 @@ fn wifi_secrets() -> io::Result<()> {
 
     // Write the SSID and password to wifi_secrets.rs
     println!("in wifi_secrets, before writing ssid and password to output file");
+    writeln!(f, "/// Wi-Fi SSID loaded from `wifi_config.json`")?;
     writeln!(f, "pub const SSID: &str = \"{ssid}\";")?;
+    writeln!(f, "/// Wi-Fi password loaded from `wifi_config.json`")?;
     writeln!(f, "pub const PASSWORD: &str = \"{password}\";")?;
     Ok(())
 }
@@ -103,6 +105,7 @@ fn time_api_config() -> io::Result<()> {
     let combined_url = format!("{baseurl}{timezone}");
 
     // Write the baseurl and timezone to time_api_secrets.rs
+    writeln!(f, "/// Time server URL loaded from `time_api.json`")?;
     writeln!(f, "pub const TIME_SERVER_URL: &str = \"{combined_url}\";")?;
     Ok(())
 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,6 +1,6 @@
 # Before upgrading check that everything is available on all tier1 targets here:
 # https://rust-lang.github.io/rustup-components-history
 [toolchain]
-channel = "1.90.0"
+channel = "1.95.0"
 components = ["rust-src", "rustfmt", "llvm-tools"]
 targets = ["thumbv6m-none-eabi"]

--- a/src/event.rs
+++ b/src/event.rs
@@ -50,4 +50,6 @@ pub enum Event {
     SunriseEffectFinished,
     /// An interactive mode (menu, settings, or setting mode) has timed out due to inactivity
     InteractiveModeTimeout,
+    /// The alarm-enabled display sleep timer has elapsed
+    DisplaySleepTimeout,
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -43,6 +43,8 @@ pub struct SystemState {
     pub manual_time_buffer: (u8, u8),
     /// The tick count of the last user interaction (for menu timeout)
     pub last_interaction_tick: u64,
+    /// Whether the display is currently on or off
+    pub display_state: DisplayState,
 }
 
 /// State transitions and operations
@@ -65,6 +67,7 @@ impl SystemState {
             system_info_page: 0,
             manual_time_buffer: (0, 0),
             last_interaction_tick: 0,
+            display_state: DisplayState::On,
         }
     }
 
@@ -159,6 +162,31 @@ impl SystemState {
         self.last_interaction_tick = tick;
     }
 
+    /// Turn the display on
+    pub const fn set_display_on(&mut self) {
+        self.display_state = DisplayState::On;
+    }
+
+    /// Turn the display off
+    pub const fn set_display_off(&mut self) {
+        self.display_state = DisplayState::Off;
+    }
+
+    /// Check if the display is off
+    pub fn is_display_off(&self) -> bool {
+        self.display_state == DisplayState::Off
+    }
+
+    /// Check if the display should sleep when the alarm is enabled
+    pub fn should_alarm_display_sleep(&self, current_tick: u64) -> bool {
+        const DISPLAY_SLEEP_TIMEOUT_MS: u64 = 30_000;
+
+        self.alarm_settings.get_enabled()
+            && matches!(self.operation_mode, OperationMode::Normal)
+            && self.display_state == DisplayState::On
+            && (current_tick.saturating_sub(self.last_interaction_tick) >= DISPLAY_SLEEP_TIMEOUT_MS)
+    }
+
     /// Check if any interactive mode should timeout (10 seconds = 10000ms of inactivity)
     pub const fn should_interactive_mode_timeout(&self, current_tick: u64) -> bool {
         matches!(
@@ -232,6 +260,15 @@ pub enum OperationMode {
     SetTimeManual,
     /// The system is in standby mode, the display is off, the neopixel ring is off, the system is in a low power state.
     Standby,
+}
+
+/// The on/off state of the display
+#[derive(Eq, PartialEq, Debug, Format, Clone)]
+pub enum DisplayState {
+    /// Display is on
+    On,
+    /// Display is off
+    Off,
 }
 
 /// User-configurable system settings (persisted to flash)

--- a/src/task/alarm_settings.rs
+++ b/src/task/alarm_settings.rs
@@ -237,25 +237,25 @@ pub async fn alarm_settings_handler(flash: Flash<'static, FLASH, Async, { FLASH_
 
     // Read the alarm settings from the flash memory only once at the start of the task
     // and send them to the event channel.
-    let alarm_settings = persisted_settings.read_alarm_settings_from_flash().await.map_or_else(
-        || {
+    let alarm_settings = persisted_settings
+        .read_alarm_settings_from_flash()
+        .await
+        .unwrap_or_else(|| {
             warn!("No alarm settings found in flash on startup, using defaults");
             AlarmSettings::new_empty()
-        },
-        |alarm_settings| alarm_settings,
-    );
+        });
 
     // Always send the event, even if we're using defaults
     send_event(Event::AlarmSettingsReadFromFlash(alarm_settings)).await;
 
     // Read the system settings from the flash memory
-    let system_settings = persisted_settings.read_system_settings_from_flash().await.map_or_else(
-        || {
+    let system_settings = persisted_settings
+        .read_system_settings_from_flash()
+        .await
+        .unwrap_or_else(|| {
             warn!("No system settings found in flash on startup, using defaults");
             SystemSettings::new_default()
-        },
-        |system_settings| system_settings,
-    );
+        });
 
     // Always send the event, even if we're using defaults
     send_event(Event::SystemSettingsReadFromFlash(system_settings)).await;

--- a/src/task/display.rs
+++ b/src/task/display.rs
@@ -27,7 +27,7 @@ use ssd1306_async::{I2CDisplayInterface, Ssd1306, prelude::*};
 use tinybmp::Bmp;
 
 use crate::{
-    state::{BatteryLevel, OperationMode, SYSTEM_STATE},
+    state::{BatteryLevel, DisplayState, OperationMode, SYSTEM_STATE},
     task::{
         buttons::Button,
         rtc_manager::{rtc_get_scheduled_alarm, rtc_get_time},
@@ -589,6 +589,7 @@ pub async fn display_handler(i2c: I2c<'static, I2C0, Async>) {
     let _ = display.set_brightness(Brightness::DIMMEST).await;
 
     let settings = Settings::new();
+    let mut display_is_off = false;
 
     'mainloop: loop {
         // Wait for a signal to update the display
@@ -620,6 +621,19 @@ pub async fn display_handler(i2c: I2c<'static, I2C0, Async>) {
 
         // Store operation mode locally to avoid move issues
         let operation_mode = system_state.operation_mode.clone();
+
+        if system_state.display_state == DisplayState::Off {
+            if !display_is_off {
+                display.clear();
+                let _ = display.flush().await;
+                display_is_off = true;
+            }
+            // Report successful display update to watchdog
+            report_task_success(TaskId::Display).await;
+            continue 'mainloop;
+        }
+
+        display_is_off = false;
 
         // prepare the display, note that nothing is sent to the display before flush()
         display.clear();

--- a/src/task/display.rs
+++ b/src/task/display.rs
@@ -28,10 +28,9 @@ use tinybmp::Bmp;
 
 use crate::{
     state::{BatteryLevel, OperationMode, SYSTEM_STATE},
-    task::rtc_manager::rtc_get_scheduled_alarm,
     task::{
         buttons::Button,
-        rtc_manager::rtc_get_time,
+        rtc_manager::{rtc_get_scheduled_alarm, rtc_get_time},
         watchdog::{TaskId, report_task_success},
     },
     utility::string_utils::StringUtils,
@@ -596,22 +595,19 @@ pub async fn display_handler(i2c: I2c<'static, I2C0, Async>) {
         wait_for_display_update().await;
 
         // Get the current time from RTC manager
-        let dt: DateTime = rtc_get_time().await.map_or_else(
-            || {
-                info!("RTC not running");
-                // Return an empty DateTime
-                DateTime {
-                    year: 0,
-                    month: 0,
-                    day: 0,
-                    day_of_week: DayOfWeek::Monday,
-                    hour: 0,
-                    minute: 0,
-                    second: 0,
-                }
-            },
-            |dt| dt,
-        );
+        let dt: DateTime = rtc_get_time().await.unwrap_or_else(|| {
+            info!("RTC not running");
+            // Return an empty DateTime
+            DateTime {
+                year: 0,
+                month: 0,
+                day: 0,
+                day_of_week: DayOfWeek::Monday,
+                hour: 0,
+                minute: 0,
+                second: 0,
+            }
+        });
 
         // get the state of the system out of the mutex and quickly drop the mutex
         let system_state_guard = SYSTEM_STATE.lock().await;

--- a/src/task/light_effects.rs
+++ b/src/task/light_effects.rs
@@ -4,7 +4,9 @@
 //! The tasks are responsible for initializing the neopixel, setting the colors of the LEDs, and updating the LEDs.
 use defmt::{info, warn};
 use defmt_rtt as _;
-use embassy_rp::{gpio::Output, peripherals::PIO1, pio_programs::ws2812::PioWs2812};
+use embassy_rp::{
+    gpio::Output, pac, pac::io::vals::Gpio0ctrlFuncsel, peripherals::PIO1, pio_programs::ws2812::PioWs2812,
+};
 use embassy_sync::{blocking_mutex::raw::CriticalSectionRawMutex, signal::Signal};
 use embassy_time::{Duration, Instant, Timer};
 use panic_probe as _;
@@ -297,10 +299,54 @@ async fn display_analog_clock(
     np.write(&bright_data).await;
 }
 
+/// Reconfigures GP15 from PIO1 control to a floating SIO input (high-impedance).
+///
+/// This must be called before cutting neopixel power via the MOSFET.
+/// When the MOSFET is off, VCC (+5V) remains connected to the WS2812B ring.
+/// Without this, the WS2812B can draw parasitic current through the DIN line:
+/// `VCC → WS2812B internals → DIN pin → GP15 → Pico GND`.
+/// Making the pin high-impedance eliminates this return path entirely.
+///
+/// # Why direct PAC access instead of `Flex`
+///
+/// At the register level, [`embassy_rp::gpio::Flex`] does exactly the same
+/// thing: `Flex::new()` sets `FUNCSEL = SIO_0` and `Flex::set_as_input()`
+/// clears the SIO output-enable bit. However, `Flex` requires *owning* the
+/// pin peripheral, and `PIN_15` was already moved into `PioWs2812::new()`
+/// via `make_pio_pin()` at startup. Using `Flex` here would require unsafely
+/// stealing the pin a second time, and `Flex::new()` would immediately
+/// reconfigure `FUNCSEL` to `SIO_0`, breaking PIO control from that point
+/// on. Direct PAC access lets us *transiently* manipulate the register
+/// without disturbing the PIO's ownership of the pin, which is exactly what
+/// the `unstable-pac` feature is intended for.
+fn float_neopixel_data_pin() {
+    // Switch GP15 function from PIO1 to SIO
+    pac::IO_BANK0.gpio(15).ctrl().modify(|w| {
+        w.set_funcsel(Gpio0ctrlFuncsel::SIO_0 as _);
+    });
+    // Clear the SIO output-enable bit → pin becomes a floating input
+    pac::SIO.gpio_oe(0).value_clr().write_value(1u32 << 15);
+}
+
+/// Restores GP15 from floating SIO input back to PIO1 control.
+///
+/// Must be called *before* enabling the neopixel power MOSFET so the
+/// WS2812B data line is driven by the PIO state machine from the moment
+/// power arrives. See [`float_neopixel_data_pin`] for the full rationale
+/// on why PAC access is used instead of [`embassy_rp::gpio::Flex`].
+fn restore_neopixel_data_pin() {
+    pac::IO_BANK0.gpio(15).ctrl().modify(|w| {
+        w.set_funcsel(Gpio0ctrlFuncsel::PIO1_0 as _);
+    });
+}
+
 /// Turns off all LEDs
 async fn turn_off_all_leds(np: &mut NeopixelType<'_>, pwr: &mut Output<'static>) {
     let data = [RGB8::default(); NUM_LEDS_USIZE];
     np.write(&data).await;
+    // Float GP15 before cutting power to break the parasitic current path
+    // that flows through the data line when VCC is still connected.
+    float_neopixel_data_pin();
     // Wait 100ms before cutting power to ensure all LEDs are off
     Timer::after(Duration::from_millis(100)).await;
     // Cut power to the Neopixel ring
@@ -475,6 +521,9 @@ async fn handle_normal_mode(
             // Power on the Neopixel ring if transitioning from Off
             if *neopixel_handle.current_led_state == LedState::Off {
                 info!("Powering on Neopixel ring");
+                // Restore data pin to PIO1 control before enabling power so the
+                // WS2812B sees a driven (low) DIN from the very first moment.
+                restore_neopixel_data_pin();
                 neopixel_handle.pwr.set_high();
                 // Small delay to let power stabilize
                 Timer::after(Duration::from_millis(10)).await;
@@ -497,6 +546,7 @@ async fn handle_alarm_mode(
             // Power on the Neopixel ring if transitioning from Off
             if *handle.current_led_state == LedState::Off {
                 info!("Powering on Neopixel ring for sunrise effect");
+                restore_neopixel_data_pin();
                 handle.pwr.set_high();
                 // Small delay to let power stabilize
                 Timer::after(Duration::from_millis(10)).await;
@@ -509,6 +559,7 @@ async fn handle_alarm_mode(
             // Power on the Neopixel ring if transitioning from Off
             if *handle.current_led_state == LedState::Off {
                 info!("Powering on Neopixel ring for noise effect");
+                restore_neopixel_data_pin();
                 handle.pwr.set_high();
                 // Small delay to let power stabilize
                 Timer::after(Duration::from_millis(10)).await;

--- a/src/task/orchestrate.rs
+++ b/src/task/orchestrate.rs
@@ -540,22 +540,19 @@ pub async fn scheduler() {
         }
 
         // Get the current time from RTC manager
-        let dt: DateTime = rtc_get_time().await.map_or_else(
-            || {
-                info!("RTC not running");
-                // Return an empty DateTime
-                DateTime {
-                    year: 0,
-                    month: 0,
-                    day: 0,
-                    day_of_week: DayOfWeek::Monday,
-                    hour: 0,
-                    minute: 0,
-                    second: 0,
-                }
-            },
-            |dt| dt,
-        );
+        let dt: DateTime = rtc_get_time().await.unwrap_or_else(|| {
+            info!("RTC not running");
+            // Return an empty DateTime
+            DateTime {
+                year: 0,
+                month: 0,
+                day: 0,
+                day_of_week: DayOfWeek::Monday,
+                hour: 0,
+                minute: 0,
+                second: 0,
+            }
+        });
 
         send_event(Event::Scheduler((dt.hour, dt.minute, dt.second))).await;
 

--- a/src/task/orchestrate.rs
+++ b/src/task/orchestrate.rs
@@ -129,24 +129,37 @@ pub async fn orchestrator() {
 async fn handle_event(event: Event, system_state: &mut SystemState) {
     match event {
         Event::BlueBtn => {
-            system_state.update_interaction_tick(Instant::now().as_millis());
+            let now_tick = Instant::now().as_millis();
+            if handle_display_wake_if_off(system_state, now_tick) {
+                return;
+            }
+            system_state.update_interaction_tick(now_tick);
             handle_blue_button_press(system_state).await;
             signal_display_update();
             handle_button_led_on_button_press(system_state);
         }
         Event::GreenBtn => {
-            system_state.update_interaction_tick(Instant::now().as_millis());
+            let now_tick = Instant::now().as_millis();
+            if handle_display_wake_if_off(system_state, now_tick) {
+                return;
+            }
+            system_state.update_interaction_tick(now_tick);
             handle_green_button_press(system_state).await;
             signal_display_update();
             handle_button_led_on_button_press(system_state);
         }
         Event::YellowBtn => {
-            system_state.update_interaction_tick(Instant::now().as_millis());
+            let now_tick = Instant::now().as_millis();
+            if handle_display_wake_if_off(system_state, now_tick) {
+                return;
+            }
+            system_state.update_interaction_tick(now_tick);
             handle_yellow_button_press(system_state).await;
             signal_display_update();
             handle_button_led_on_button_press(system_state);
         }
         Event::InteractiveModeTimeout => handle_interactive_mode_timeout_event(system_state).await,
+        Event::DisplaySleepTimeout => handle_display_sleep_timeout_event(system_state),
         Event::Vbus(usb) => handle_vbus_event(system_state, usb),
         Event::Vsys(voltage) => handle_vsys_event(system_state, voltage),
         Event::AlarmSettingsReadFromFlash(alarm_settings) => {
@@ -186,6 +199,27 @@ async fn handle_interactive_mode_timeout_event(system_state: &mut SystemState) {
     }
     system_state.set_normal_mode();
     signal_display_update();
+}
+
+/// Handles waking the display if it is currently off.
+/// Returns true if the button press should be consumed for wake-up only.
+fn handle_display_wake_if_off(system_state: &mut SystemState, now_tick: u64) -> bool {
+    if system_state.is_display_off() {
+        system_state.set_display_on();
+        system_state.update_interaction_tick(now_tick);
+        signal_display_update();
+        return true;
+    }
+    false
+}
+
+/// Handles the alarm-enabled display sleep timeout
+fn handle_display_sleep_timeout_event(system_state: &mut SystemState) {
+    let now_tick = Instant::now().as_millis();
+    if system_state.should_alarm_display_sleep(now_tick) {
+        system_state.set_display_off();
+        signal_display_update();
+    }
 }
 
 /// Handles USB power state changes
@@ -332,6 +366,7 @@ fn handle_alarm_event(system_state: &mut SystemState) {
     info!("Alarm event");
     system_state.randomize_alarm_stop_button_sequence();
     system_state.set_alarm_mode();
+    system_state.set_display_on();
     signal_display_update();
     signal_lightfx_start(0, 0, 0);
     signal_button_leds(ButtonLedCommand::On);
@@ -342,6 +377,8 @@ fn handle_alarm_stop_event(system_state: &mut SystemState) {
     info!("Alarm stop event");
     if system_state.alarm_state.is_active() {
         system_state.set_normal_mode();
+        system_state.set_display_on();
+        system_state.update_interaction_tick(Instant::now().as_millis());
         signal_display_update();
         signal_lightfx_stop();
         signal_lightfx_start(0, 0, 0);
@@ -575,6 +612,17 @@ pub async fn scheduler() {
 
             if should_timeout {
                 send_event(Event::InteractiveModeTimeout).await;
+            }
+
+            let should_sleep: bool = {
+                let system_state_guard = SYSTEM_STATE.lock().await;
+                system_state_guard
+                    .as_ref()
+                    .is_some_and(|state| state.should_alarm_display_sleep(current_tick))
+            };
+
+            if should_sleep {
+                send_event(Event::DisplaySleepTimeout).await;
             }
         }
 

--- a/src/task/sound.rs
+++ b/src/task/sound.rs
@@ -3,6 +3,7 @@
 //!
 //! The task is responsible for initializing the `DFPlayer` Mini module, powering it on, playing a sound, and powering it off.
 use core::sync::atomic::{AtomicBool, Ordering};
+
 use defmt::{Debug2Format, info};
 use dfplayer_async::{DfPlayer, Equalizer, PlayBackSource, TimeSource};
 use embassy_futures::select::{Either, select};


### PR DESCRIPTION
This pull request introduces a new display sleep feature to the Raspberry Pi Pico W alarm clock, improves hardware safety for the WS2812B LED ring, and updates several dependencies and toolchain versions. The most important changes include implementing automatic display sleep when the alarm is enabled, adding safe handling for the Neopixel data pin, updating dependencies, and improving code robustness and documentation.

**Display Sleep Feature and State Management:**

* Added a new `DisplayState` enum and related methods to `SystemState` in `src/state.rs`, enabling the display to be turned on/off and to check/display sleep status. The display now automatically sleeps after 30 seconds of inactivity when the alarm is enabled and wakes on button press. New event `DisplaySleepTimeout` and related handlers were introduced to orchestrate this behavior. (`[[1]](diffhunk://#diff-87619baf236177a7a9fc38150961151b7583b6f2f082ade75915f3ac4ca49c41R46-R47)`, `[[2]](diffhunk://#diff-87619baf236177a7a9fc38150961151b7583b6f2f082ade75915f3ac4ca49c41R70)`, `[[3]](diffhunk://#diff-87619baf236177a7a9fc38150961151b7583b6f2f082ade75915f3ac4ca49c41R165-R189)`, `[[4]](diffhunk://#diff-87619baf236177a7a9fc38150961151b7583b6f2f082ade75915f3ac4ca49c41R265-R273)`, `[[5]](diffhunk://#diff-14da7c350de5742eaa248de110fefeae9b4b639c0358e26024d6040ccf174a41R53-R54)`, `[[6]](diffhunk://#diff-823d0daa285dc99caf92368d74840718ba9ae21c3e429080c30c493f733b8ac3L132-R162)`, `[[7]](diffhunk://#diff-823d0daa285dc99caf92368d74840718ba9ae21c3e429080c30c493f733b8ac3R204-R224)`, `[[8]](diffhunk://#diff-823d0daa285dc99caf92368d74840718ba9ae21c3e429080c30c493f733b8ac3R369)`, `[[9]](diffhunk://#diff-823d0daa285dc99caf92368d74840718ba9ae21c3e429080c30c493f733b8ac3R380-R381)`, `[[10]](diffhunk://#diff-fa08ea98ccd8f2ff6c0a345b0afcfb6e7cdfd5f3d2a44d211b41deb6a49249afL30-R33)`, `[[11]](diffhunk://#diff-fa08ea98ccd8f2ff6c0a345b0afcfb6e7cdfd5f3d2a44d211b41deb6a49249afR625-R637)`)

**Neopixel/WS2812B Hardware Safety:**

* Introduced `float_neopixel_data_pin` and `restore_neopixel_data_pin` functions in `src/task/light_effects.rs` to safely manage the GP15 data pin, preventing parasitic current draw when the Neopixel ring is powered off. These are now called before cutting or restoring power to the LED ring. (`[[1]](diffhunk://#diff-75a1a9ad77fc229290339f8e6e527ef67ed9d236449e47400cb9505034cbf2d1R302-R349)`, `[[2]](diffhunk://#diff-75a1a9ad77fc229290339f8e6e527ef67ed9d236449e47400cb9505034cbf2d1R524-R526)`, `[[3]](diffhunk://#diff-75a1a9ad77fc229290339f8e6e527ef67ed9d236449e47400cb9505034cbf2d1R549)`, `[[4]](diffhunk://#diff-75a1a9ad77fc229290339f8e6e527ef67ed9d236449e47400cb9505034cbf2d1R562)`)

**Dependency and Toolchain Updates:**

* Updated the Rust toolchain to 1.95.0 in `rust-toolchain.toml` and bumped versions of several dependencies (`pio-proc`, `tinybmp`) in `Cargo.toml` for better compatibility and features. The project version is now `0.8.0`. (`[[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L3-R3)`, `[[2]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L75-R79)`, `[[3]](diffhunk://#diff-2b1bde2cf3a858b7bf7424cb8bcbf01f35b94dc80b925d9432cbab3319ca9b4eL4-R4)`)

**Code Robustness and Documentation:**

* Replaced deprecated `.map_or_else` usage with `.unwrap_or_else` for reading settings and RTC time, improving code clarity in `src/task/alarm_settings.rs`, `src/task/display.rs`, and `src/task/orchestrate.rs`. (`[[1]](diffhunk://#diff-2bde8ee24f474bd60063958bcef2af887ba3daaab41a39f05defeec41fe3ac3dL240-R258)`, `[[2]](diffhunk://#diff-fa08ea98ccd8f2ff6c0a345b0afcfb6e7cdfd5f3d2a44d211b41deb6a49249afR592-R599)`, `[[3]](diffhunk://#diff-fa08ea98ccd8f2ff6c0a345b0afcfb6e7cdfd5f3d2a44d211b41deb6a49249afL612-R611)`, `[[4]](diffhunk://#diff-823d0daa285dc99caf92368d74840718ba9ae21c3e429080c30c493f733b8ac3L543-R580)`)
* Added doc comments to generated Wi-Fi and time server secret constants in `build.rs` for better maintainability. (`[[1]](diffhunk://#diff-d0d98998092552a1d3259338c2c71e118a5b8343dd4703c0c7f552ada7f9cb42R65-R67)`, `[[2]](diffhunk://#diff-d0d98998092552a1d3259338c2c71e118a5b8343dd4703c0c7f552ada7f9cb42R108)`)

These changes collectively enhance the device's user experience, hardware safety, and code quality.